### PR TITLE
固定値をグローバル変数を返す関数から取得するように変更

### DIFF
--- a/global_number.py
+++ b/global_number.py
@@ -1,0 +1,82 @@
+
+def get_c_air() -> float:
+    """
+    Returns:
+        空気の定圧比熱, J/(kg・K)
+    """
+
+    return 1006.0
+
+
+def get_rho_air() -> float:
+    """
+    Returns:
+        空気の密度, kg/m3
+    """
+
+    return 1.2
+
+
+def get_g() -> float:
+    """
+    Returns:
+        重力加速度, m/s**2
+    """
+
+    return 9.8
+
+
+def get_lambda_air() -> float:
+    """
+    Returns:
+        空気の熱伝導率, W/(m・K)
+    """
+    return 0.026
+
+
+def get_beta_air() -> float:
+    """
+    Returns:
+        空気の体膨張率, 1/K
+    """
+    return 3.7e-3
+
+
+def get_mu_air() -> float:
+    """
+    Returns:
+        空気の粘性率, Pa・s
+    """
+    return 1.8e-5
+
+
+def get_sgm() -> float:
+    """
+    Returns:
+        ステファンボルツマン定数
+    """
+    return 5.67e-8
+
+
+def get_abs_temp() -> float:
+    """
+    Returns:
+        絶対温度, K
+    """
+    return 273.15
+
+
+def get_h_out() -> float:
+    """
+    Returns:
+        室外側総合熱伝達率, W/(m2・K)
+    """
+    return 25.0
+
+
+def get_h_in() -> float:
+    """
+    Returns:
+        室内側総合熱伝達率, W/(m2・K)
+    """
+    return 9.0

--- a/heat_transfer_coefficient.py
+++ b/heat_transfer_coefficient.py
@@ -1,4 +1,5 @@
 import math
+from global_number import get_abs_temp, get_sgm, get_g, get_lambda_air, get_beta_air, get_mu_air
 
 
 # 有効放射率の計算（無限の平行面の場合）
@@ -15,27 +16,23 @@ def effective_emissivity_two_dimension(emissivity_1, emissivity_2, l_d, l_s):
 
 # 放射熱伝達率[W/(m2・K)]の計算
 def radiative_heat_transfer_coefficient(theta_1, theta_2, effective_emissivity):
-    t_m = (theta_1 + 273.15 + theta_2 + 273.15) / 2
-    sigma = 5.67 * (10 ** (-8))  # ステファン・ボルツマン定数（W/(m^2・K^4)）
-    h_r = 4 * sigma * effective_emissivity * (t_m ** 3)
+    t_m = (theta_1 + get_abs_temp() + theta_2 + get_abs_temp()) / 2
+    h_r = 4 * get_sgm() * effective_emissivity * (t_m ** 3)
     return h_r
 
 
 # 対流熱伝達率の計算[W/(m2・K)]
-def convective_heat_transfer_coefficient(v_a, theta_1, theta_2, angle, l_h, l_d):
-
-    # 固定値を設定
-    lambda_a = 0.026  # 空気の熱伝導率, W/(m・K)
+def convective_heat_transfer_coefficient(v_a, theta_1, theta_2, angle, l_h, l_d, c_a, rho_a):
 
     if theta_1 == theta_2:
         # 両表面の温度（theta_1とtheta_2）が同じ値のときはh_c = 1とする
         h_c = 1
     else:
         # ヌセルト数を計算
-        nusselt_number = get_nusselt_number(theta_1, theta_2, angle, l_h, l_d)
+        nusselt_number = get_nusselt_number(theta_1, theta_2, angle, l_h, l_d, c_a, rho_a)
 
         # 密閉空気層の自然対流熱伝達率を計算
-        h_base = nusselt_number * lambda_a / l_d
+        h_base = nusselt_number * get_lambda_air() / l_d
 
         # 通気層の対流熱伝達率の計算
         h_c = 2 * h_base * 4 * v_a
@@ -44,18 +41,10 @@ def convective_heat_transfer_coefficient(v_a, theta_1, theta_2, angle, l_h, l_d)
 
 
 # ヌセルト数の計算
-def get_nusselt_number(theta_1, theta_2, angle, l_h, l_d):
-
-    # 固定値を設定
-    g = 9.8                     # 重力加速度,m/s^2
-    beta_a = 3.7 * (10 ** -3)    # 空気の体膨張率, 1/K
-    lambda_a = 0.026            # 空気の熱伝導率, W/(m・K)
-    c_a = 1006                 # 空気の定圧比熱, J/(kg・K)
-    rho_a = 1.2                 # 空気の密度, kg/m3
-    mu_a = 1.8 * (10 ** -5)     # 空気の粘性率, Pa・s
+def get_nusselt_number(theta_1, theta_2, angle, l_h, l_d, c_a, rho_a):
 
     # レーリー数の計算
-    rayleigh_number = (g * beta_a * abs((theta_1 + 273.15) - (theta_2 + 273.15)) * (l_d ** 3) * (rho_a ** 2) * c_a) / (mu_a * lambda_a)
+    rayleigh_number = (get_g() * get_beta_air() * abs((theta_1 + get_abs_temp()) - (theta_2 + get_abs_temp())) * (l_d ** 3) * (rho_a ** 2) * c_a) / (get_mu_air() * get_lambda_air())
 
     # ヌセルト数の計算
     nusselt_number = 0

--- a/validation.py
+++ b/validation.py
@@ -1,12 +1,18 @@
+import global_number
 import ventilation_wall as vw
 import envelope_performance_factors as ep
-
 
 def validation():
     '''
     通気層を有する壁体の熱貫流率の検証
     :return:
     '''
+
+    # 固定値の設定
+    c_a = global_number.get_c_air()
+    rho_a = global_number.get_rho_air()
+    h_out = global_number.get_h_out()
+    h_in = global_number.get_h_in()
 
     # パラメータの設定
     theta_e = 0.0
@@ -32,7 +38,7 @@ def validation():
                           emissivity_2=0.9)
 
     # 通気層の状態値を取得
-    status = vw.get_wall_status_values(parms)
+    status = vw.get_wall_status_values(parms, c_a, rho_a, h_out, h_in)
 
     # 温度状態値の出力
     print('各部温度')
@@ -42,7 +48,7 @@ def validation():
 
     # 熱流の出力
     print('屋外表面熱流')
-    print(vw.get_heat_flow_0(matrix_temp=status.matrix_temp, param=parms))
+    print(vw.get_heat_flow_0(matrix_temp=status.matrix_temp, param=parms, h_out=h_out))
 
     # 外装材伝導熱流の出力
     print('外装材伝導熱流')
@@ -54,7 +60,7 @@ def validation():
 
     # 通気層排気熱量
     print('通気層からの排気熱量')
-    print(vw.get_heat_flow_exhaust(matrix_temp=status.matrix_temp, param=parms, theta_as_in=parms.theta_e, h_cv=status.h_cv))
+    print(vw.get_heat_flow_exhaust(matrix_temp=status.matrix_temp, param=parms, theta_as_in=parms.theta_e, h_cv=status.h_cv, c_a=c_a, rho_a=rho_a))
 
     # 通気層内表面から通気層空気への熱流
     print('通気層内表面から通気層空気への熱流')
@@ -66,7 +72,7 @@ def validation():
 
     # 室内表面熱流の計算
     print('室内表面熱流')
-    q = vw.get_heat_flow_4(matrix_temp=status.matrix_temp, param=parms)
+    q = vw.get_heat_flow_4(matrix_temp=status.matrix_temp, param=parms, h_in=h_in)
     print(q)
 
     # 通気層を考慮した熱貫流率

--- a/validation0.py
+++ b/validation0.py
@@ -1,3 +1,4 @@
+import global_number
 import ventilation_wall as vw
 import envelope_performance_factors as ep
 
@@ -8,6 +9,12 @@ def validation0():
     通気風量0での検証
     :return:
     '''
+
+    # 固定値の設定
+    c_a = global_number.get_c_air()
+    rho_a = global_number.get_rho_air()
+    h_out = global_number.get_h_out()
+    h_in = global_number.get_h_in()
 
     # パラメータの設定
     theta_e = 0.0
@@ -33,7 +40,7 @@ def validation0():
                           emissivity_2=0.9)
 
     # 通気層の状態値を取得
-    status = vw.get_wall_status_values(parms)
+    status = vw.get_wall_status_values(parms, c_a, rho_a, h_out, h_in)
 
     # 温度状態値の出力
     print('各部温度')
@@ -43,7 +50,7 @@ def validation0():
 
     # 熱流の出力
     print('屋外表面熱流')
-    print(vw.get_heat_flow_0(matrix_temp=status.matrix_temp, param=parms))
+    print(vw.get_heat_flow_0(matrix_temp=status.matrix_temp, param=parms, h_out=h_out))
 
     # 外装材伝導熱流の出力
     print('外装材伝導熱流')
@@ -55,7 +62,7 @@ def validation0():
 
     # 通気層排気熱量
     print('通気層からの排気熱量')
-    print(vw.get_heat_flow_exhaust(matrix_temp=status.matrix_temp, param=parms, theta_as_in=parms.theta_e, h_cv=status.h_cv))
+    print(vw.get_heat_flow_exhaust(matrix_temp=status.matrix_temp, param=parms, theta_as_in=parms.theta_e, h_cv=status.h_cv, c_a=c_a, rho_a=rho_a))
 
     # 通気層内表面から通気層空気への熱流
     print('通気層内表面から通気層空気への熱流')
@@ -67,7 +74,7 @@ def validation0():
 
     # 室内表面熱流の計算
     print('室内表面熱流')
-    q = vw.get_heat_flow_4(matrix_temp=status.matrix_temp, param=parms)
+    q = vw.get_heat_flow_4(matrix_temp=status.matrix_temp, param=parms, h_in=h_in)
     print(q)
 
     # 通気層を考慮した熱貫流率

--- a/ventilation_wall.py
+++ b/ventilation_wall.py
@@ -87,7 +87,7 @@ def get_heat_balance(matrix_temp: np.zeros(shape=(5, 1)), parm: Parameters) -> n
     theta_2 = matrix_temp[2][0]
 
     # 対流熱伝達率の計算
-    h_cv = heat_transfer_coefficient.convective_heat_transfer_coefficient(parm.v_a, theta_1, theta_2, parm.angle, parm.l_h, parm.l_d)
+    h_cv = heat_transfer_coefficient.convective_heat_transfer_coefficient(parm.v_a, theta_1, theta_2, parm.angle, parm.l_h, parm.l_d, c_a, rho_a)
 
     # 有効放射率の計算
     effective_emissivity = heat_transfer_coefficient.effective_emissivity_parallel(parm.emissivity_1, parm.emissivity_2)
@@ -152,7 +152,7 @@ def get_wall_status_values(parm: Parameters) -> WallStatusValues:
 
     # 対流熱伝達率の計算
     h_cv = heat_transfer_coefficient.convective_heat_transfer_coefficient(parm.v_a, matrix_temp_fixed[1][0], matrix_temp_fixed[2][0], parm.angle,
-                                                                          parm.l_h, parm.l_d)
+                                                                          parm.l_h, parm.l_d, c_a, rho_a)
 
     # 有効放射率の計算
     effective_emissivity = heat_transfer_coefficient.effective_emissivity_parallel(parm.emissivity_1, parm.emissivity_2)

--- a/ventilation_wall.py
+++ b/ventilation_wall.py
@@ -66,14 +66,7 @@ class WallStatusValues:
 
 
 # 熱収支式を解く関数
-def get_heat_balance(matrix_temp: np.zeros(shape=(5, 1)), parm: Parameters) -> np.zeros(shape=(5, 1)):
-
-    # 固定値を設定
-    # Note: パラメータごとにこれらの値を計算する方法もあるが、ひとまず固定値とする
-    h_out = 25.0  # 室外側総合熱伝達率, W/(m2・K)
-    h_in = 9.0  # 室内側総合熱伝達率, W/(m2・K)
-    c_a = 1006  # 空気の定圧比熱, J/(kg・K)
-    rho_a = 1.2  # 空気の密度, kg/m3
+def get_heat_balance(matrix_temp: np.zeros(shape=(5, 1)), parm: Parameters, c_a: float, rho_a: float, h_out: float, h_in: float) -> np.zeros(shape=(5, 1)):
 
     # 相当外気温度を計算
     theta_SAT = parm.theta_e + (parm.a_surf * parm.J_surf) / h_out
@@ -136,7 +129,7 @@ def get_heat_balance(matrix_temp: np.zeros(shape=(5, 1)), parm: Parameters) -> n
 
 
 # 通気層の状態値を取得する
-def get_wall_status_values(parm: Parameters) -> WallStatusValues:
+def get_wall_status_values(parm: Parameters, c_a: float, rho_a: float, h_out: float, h_in: float) -> WallStatusValues:
 
     # 通気層内の各点の温度の初期値を設定
     matrix_temp = np.zeros(shape=(5, 1))
@@ -147,7 +140,7 @@ def get_wall_status_values(parm: Parameters) -> WallStatusValues:
     matrix_temp[4][0] = (matrix_temp[1][0] + matrix_temp[2][0]) / 2
 
     # 通気層内の各点の熱収支式が成り立つときの各点の温度を取得
-    answer_T = optimize.root(fun=get_heat_balance, x0=matrix_temp, args=parm, method='broyden1')
+    answer_T = optimize.root(fun=get_heat_balance, x0=matrix_temp, args=(parm, c_a, rho_a, h_out, h_in), method='broyden1')
     matrix_temp_fixed = answer_T.x
 
     # 対流熱伝達率の計算

--- a/ventilation_wall.py
+++ b/ventilation_wall.py
@@ -155,17 +155,17 @@ def get_wall_status_values(parm: Parameters, c_a: float, rho_a: float, h_out: fl
 
     return WallStatusValues(matrix_temp = matrix_temp_fixed, h_cv = h_cv, h_rv = h_rv)
 
-def get_heat_flow_0(matrix_temp: np.ndarray, param: Parameters) -> float:
+
+def get_heat_flow_0(matrix_temp: np.ndarray, param: Parameters, h_out: float) -> float:
 
     '''
     各部温度から屋外側表面熱流を計算する
     :param matrix_temp: 各部温度計算結果 (5,1), C
     :param param: 計算条件パラメータ群
+    :param h_out: 室外側総合熱伝達率, W/(m2・K)
     :return:屋外側表面熱流, W/m2
     '''
 
-    # Note: パラメータごとにこれらの値を計算する方法もあるが、ひとまず固定値とする
-    h_out = 25.0  # 室外側総合熱伝達率, W/(m2・K)
     # 相当外気温度を計算
     theta_sat = param.theta_e + (param.a_surf * param.J_surf) / h_out
 
@@ -184,22 +184,21 @@ def get_heat_flow_1(matrix_temp: np.ndarray, param: Parameters) -> float:
     return param.C_1 * (matrix_temp[0][0] - matrix_temp[1][0])
 
 
-def get_heat_flow_exhaust(matrix_temp: np.ndarray, param: Parameters, theta_as_in: float, h_cv: float) -> float:
+def get_heat_flow_exhaust(matrix_temp: np.ndarray, param: Parameters, theta_as_in: float, h_cv: float, c_a: float, rho_a: float) -> float:
 
     '''
     通気層からの排気熱量の計算
     :param matrix_temp: 各部温度計算結果 (5,1), C
     :param param: 計算条件パラメータ群
-    :theta_as_in: 通気層への流入温度=外気温度, C
-    :h_cv: 通気層の対流熱伝達率, W/m2K
+    :param theta_as_in: 通気層への流入温度=外気温度, C
+    :param h_cv: 通気層の対流熱伝達率, W/m2K
+    :param c_a: 空気の定圧比熱, J/(kg・K)
+    :param rho_a: 空気の密度, kg/m3
     :return: 通気層の排気熱量, W/m2
     '''
 
     if param.v_a > 0.0:
-        # 固定値を設定
-        # Note: パラメータごとにこれらの値を計算する方法もあるが、ひとまず固定値とする
-        c_a = 1006  # 空気の定圧比熱, J/(kg・K)
-        rho_a = 1.2  # 空気の密度, kg/m3
+
         # 通気風量の計算
         v_vent = param.v_a * param.l_d * param.l_w
 
@@ -255,18 +254,15 @@ def get_heat_flow_3(matrix_temp: np.ndarray, param: Parameters) -> float:
     return param.C_2 * (matrix_temp[2][0] - matrix_temp[3][0])
 
 
-def get_heat_flow_4(matrix_temp: np.ndarray, param: Parameters) -> float:
+def get_heat_flow_4(matrix_temp: np.ndarray, param: Parameters, h_in: float) -> float:
 
     '''
     各部温度から室内表面熱流を計算する
     :param matrix_temp: 各部温度計算結果 (5,1), C
     :param param: 計算条件パラメータ群
+    :param h_in: 室内側総合熱伝達率, W/(m2・K)
     :return: 断熱材+内装材伝導熱量, W/m2
     '''
-
-    # 固定値を設定
-    # Note: パラメータごとにこれらの値を計算する方法もあるが、ひとまず固定値とする
-    h_in = 9.0  # 室内側総合熱伝達率, W/(m2・K)
 
     return h_in * (matrix_temp[3][0] - param.theta_r)
 

--- a/ventilation_wall_test.ipynb
+++ b/ventilation_wall_test.ipynb
@@ -9,7 +9,8 @@
     "import numpy as np\n",
     "from matplotlib import pyplot as plt\n",
     "import ventilation_wall\n",
-    "import envelope_performance_factors"
+    "import envelope_performance_factors\n",
+    "import global_number"
    ]
   },
   {
@@ -38,12 +39,31 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 外気温度を設定"
+    "### 定数を設定"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c_a = global_number.get_c_air() # 空気の定圧比熱, J/(kg・K)\n",
+    "rho_a = global_number.get_rho_air() # 空気の密度, kg/m3\n",
+    "h_out = global_number.get_h_out() # 室外側総合熱伝達率, W/(m2・K)\n",
+    "h_in = global_number.get_h_in() # 室内側総合熱伝達率, W/(m2・K)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 外気温度を設定"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,7 +79,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,7 +110,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,11 +133,11 @@
     "    x1[i] = parm.theta_e\n",
     "    \n",
     "    # 通気層の状態値を取得\n",
-    "    status_buf: ventilation_wall.WallStatusValues = ventilation_wall.get_wall_status_values(parm)\n",
+    "    status_buf: ventilation_wall.WallStatusValues = ventilation_wall.get_wall_status_values(parm, c_a, rho_a, h_out, h_in)\n",
     "    status.append(status_buf)\n",
     "    \n",
     "    # 各層の熱収支を検算\n",
-    "    q = ventilation_wall.get_heat_balance(status_buf.matrix_temp,parm)\n",
+    "    q = ventilation_wall.get_heat_balance(status_buf.matrix_temp,parm, c_a, rho_a, h_out, h_in)\n",
     "    q_surf_out[i] = q[0][0]\n",
     "    q_surf_1[i] = q[1][0]\n",
     "    q_surf_2[i] = q[2][0]\n",
@@ -141,7 +161,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -186,7 +206,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -231,7 +251,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -257,7 +277,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {


### PR DESCRIPTION
@satoh-er 
グローバル変数を返す関数を定義し、固定値（定数）はこの関数から取得するように変更しました。
各種計算を行う関数には、基本的に定数も引数として渡すように変更しています。
ただし、heat_transfer_coefficient.pyにはその関数内でしか使わない定数が多いので、その場合は引数ではなく都度グローバル変数を返す関数を呼び出すようにしています。